### PR TITLE
Handle command output when json is unseparated

### DIFF
--- a/tests/raw_data
+++ b/tests/raw_data
@@ -1,0 +1,122 @@
+{
+	"period": {
+		"duration": 0.006471,
+		"unit": "ms"
+	},
+	"frequency": {
+		"requested": 0.000000,
+		"actual": 0.000000,
+		"unit": "MHz"
+	},
+	"interrupts": {
+		"count": 0.000000,
+		"unit": "irq/s"
+	},
+	"rc6": {
+		"value": 92.505022,
+		"unit": "%"
+	},
+	"power": {
+		"GPU": 0.000000,
+		"Package": 0.000000,
+		"unit": "W"
+	},
+	"imc-bandwidth": {
+		"reads": 2424.051175,
+		"writes": 2263.705378,
+		"unit": "MiB/s"
+	},
+	"engines": {
+		"Render/3D/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Blitter/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Video/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Video/1": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"VideoEnhance/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		}
+	}
+}
+{
+	"period": {
+		"duration": 1000.178248,
+		"unit": "ms"
+	},
+	"frequency": {
+		"requested": 745.867051,
+		"actual": 734.869011,
+		"unit": "MHz"
+	},
+	"interrupts": {
+		"count": 846.849051,
+		"unit": "irq/s"
+	},
+	"rc6": {
+		"value": 48.368684,
+		"unit": "%"
+	},
+	"power": {
+		"GPU": 2.289082,
+		"Package": 15.164106,
+		"unit": "W"
+	},
+	"imc-bandwidth": {
+		"reads": 3039.110933,
+		"writes": 1879.934315,
+		"unit": "MiB/s"
+	},
+	"engines": {
+		"Render/3D/0": {
+			"busy": 6.807341,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Blitter/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Video/0": {
+			"busy": 3.846153,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"Video/1": {
+			"busy": 2.247125,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		},
+		"VideoEnhance/0": {
+			"busy": 0.000000,
+			"sema": 0.000000,
+			"wait": 0.000000,
+			"unit": "%"
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the ability to handle unseparated JSON received from the `/usr/bin/intel_gpu_top -J` command output. It also allows the collector to handle cases where the command produces multiple JSON documents.

For example, on my system, the output from `/intel_gpu_top -J` results in JSON output like this – it's missing a comma that separates the two top-level JSON documents that provide the metrics being exported, which causes the `DataCollector.collect()` to raise a `JSONDecodeError` with `Expecting ',' delimiter`:
<details><summary>Expand</summary>

```json
{
	"period": {
		"duration": 0.006471,
		"unit": "ms"
	},
	"frequency": {
		"requested": 0.000000,
		"actual": 0.000000,
		"unit": "MHz"
	},
	"interrupts": {
		"count": 0.000000,
		"unit": "irq/s"
	},
	"rc6": {
		"value": 92.505022,
		"unit": "%"
	},
	"power": {
		"GPU": 0.000000,
		"Package": 0.000000,
		"unit": "W"
	},
	"imc-bandwidth": {
		"reads": 2424.051175,
		"writes": 2263.705378,
		"unit": "MiB/s"
	},
	"engines": {
		"Render/3D/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Blitter/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Video/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Video/1": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"VideoEnhance/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		}
	}
}
{
	"period": {
		"duration": 1000.178248,
		"unit": "ms"
	},
	"frequency": {
		"requested": 745.867051,
		"actual": 734.869011,
		"unit": "MHz"
	},
	"interrupts": {
		"count": 846.849051,
		"unit": "irq/s"
	},
	"rc6": {
		"value": 48.368684,
		"unit": "%"
	},
	"power": {
		"GPU": 2.289082,
		"Package": 15.164106,
		"unit": "W"
	},
	"imc-bandwidth": {
		"reads": 3039.110933,
		"writes": 1879.934315,
		"unit": "MiB/s"
	},
	"engines": {
		"Render/3D/0": {
			"busy": 6.807341,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Blitter/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Video/0": {
			"busy": 3.846153,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"Video/1": {
			"busy": 2.247125,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		},
		"VideoEnhance/0": {
			"busy": 0.000000,
			"sema": 0.000000,
			"wait": 0.000000,
			"unit": "%"
		}
	}
}
```

</details>

Instead of making a string translation and interpolating the raw output into a JSON array, the code in this PR creates a `json.JSONDecoder` instance and uses its `raw_decode()` method to iteratively scan the raw output for contained JSON objects. This produces the same `data` list of dicts as before – the only difference is how it handles the input.

Additionally, I updated the `DataCollector.collect()` method to collect metrics from each (there seems to always be two) JSON document produced by command. Previously, only the second (`data[1]`) dict was used to yield metrics. If this is undesired behavior (e.g. the first (`data[0]`) dict has bad data?), I can update the PR to remove that change.