### PR TITLE
fix json parse breaking because of comma

### DIFF
--- a/intel-gpu-exporter.py
+++ b/intel-gpu-exporter.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             output += line
 
             try:
-                data = json.loads(output)
+                data = json.loads(output.strip(","))
                 logging.debug(data)
                 update(data)
                 output = ""


### PR DESCRIPTION
This PR fixes the JSON parse breaking due to an extra comma being sent by intel_gpu_top after the first JSON dump.

Stripping the current output with `.strip(",")` seems to fix the issue for me.

fixes #25