### PR TITLE
feat: Add compute engine support & intel_gpu_top v2.28+ compatibility for Arc A750

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.13-slim
+FROM docker.io/library/debian:trixie-slim
 
 ENV \
     DEBCONF_NONINTERACTIVE_SEEN="true" \
@@ -24,6 +24,8 @@ RUN \
     apt-get install --no-install-recommends -y \
         catatonit \
         intel-gpu-tools \
+        python3 \
+        python3-pip \
     && pip install --requirement requirements.txt \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && apt-get autoremove -y \
@@ -34,7 +36,7 @@ RUN \
         /var/cache/apt/* \
         /var/tmp/*
 
-ENTRYPOINT ["/usr/bin/catatonit", "--", "/usr/local/bin/python"]
+ENTRYPOINT ["/usr/bin/catatonit", "--", "/usr/bin/python3"]
 CMD ["/app/intel-gpu-exporter.py"]
 
 LABEL \

--- a/examples/simple-grafana-dash.json
+++ b/examples/simple-grafana-dash.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 2,
-  "id": 15,
+  "id": 5,
   "links": [
     {
       "asDropdown": true,
@@ -39,7 +39,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
       "fieldConfig": {
         "defaults": {
@@ -53,6 +53,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -111,10 +112,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -122,7 +125,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_render_3d_0_busy{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_render_3d_busy",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -134,7 +137,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_render_3d_0_sema{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_render_3d_sema",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -147,7 +150,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_render_3d_0_wait{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_render_3d_wait",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -161,7 +164,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
       "fieldConfig": {
         "defaults": {
@@ -175,6 +178,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -216,32 +220,7 @@
           },
           "unit": "percent"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "igpu_engines_blitter_0_busy"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -258,10 +237,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -269,7 +250,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_blitter_0_busy{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_blitter_busy",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -281,7 +262,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_blitter_0_sema{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_blitter_sema",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -294,7 +275,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_blitter_0_wait{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_blitter_wait",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -308,7 +289,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
       "fieldConfig": {
         "defaults": {
@@ -322,6 +303,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -380,10 +362,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -391,7 +375,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_0_busy{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_busy",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -403,7 +387,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_0_sema{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_sema",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -416,7 +400,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_0_wait{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_wait",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -430,7 +414,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
       "description": "",
       "fieldConfig": {
@@ -445,6 +429,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -503,10 +488,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -514,7 +501,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_enhance_0_busy{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_enhance_busy",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -526,7 +513,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_enhance_0_sema{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_enhance_sema",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -539,7 +526,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_engines_video_enhance_0_wait{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_video_enhance_wait",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -553,9 +540,8 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -568,6 +554,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -607,7 +594,7 @@
               }
             ]
           },
-          "unit": "rotmhz"
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -617,7 +604,7 @@
         "x": 0,
         "y": 16
       },
-      "id": 10,
+      "id": 13,
       "options": {
         "legend": {
           "calcs": [],
@@ -626,10 +613,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -637,7 +626,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_frequency_actual{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_compute_busy",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -649,21 +638,34 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_frequency_requested{instance=~\"${Instance}\"}",
+          "expr": "gpu_engines_compute_sema",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+          },
+          "editorMode": "code",
+          "expr": "gpu_engines_compute_wait",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Frequency",
+      "title": "Compute",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+        "uid": "edvvtg0kxx9mod"
       },
       "description": "",
       "fieldConfig": {
@@ -678,6 +680,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -736,10 +739,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "datasource": {
@@ -747,7 +752,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_imc_bandwidth_reads{instance=~\"${Instance}\"}",
+          "expr": "gpu_imc_bandwidth_reads",
           "instant": false,
           "legendFormat": "{{__name__}}",
           "range": true,
@@ -759,7 +764,7 @@
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
           "editorMode": "code",
-          "expr": "igpu_imc_bandwidth_writes{instance=~\"${Instance}\"}",
+          "expr": "gpu_imc_bandwidth_writes",
           "hide": false,
           "instant": false,
           "legendFormat": "{{__name__}}",
@@ -771,379 +776,362 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "edvvtg0kxx9mod"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rotmhz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+          },
+          "editorMode": "code",
+          "expr": "gpu_frequency_actual",
+          "instant": false,
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+          },
+          "editorMode": "code",
+          "expr": "gpu_frequency_requested",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Frequency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 32
       },
       "id": 4,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+      "panels": [],
+      "title": "Misc",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "edvvtg0kxx9mod"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "watt"
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 25
-          },
-          "id": 1,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
             },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-              },
-              "editorMode": "code",
-              "expr": "igpu_power_package{instance=~\"${Instance}\"}",
-              "instant": false,
-              "legendFormat": "{{__name__}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-              },
-              "editorMode": "code",
-              "expr": "igpu_power_gpu{instance=~\"${Instance}\"}",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{__name__}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "iGPU Power",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "none"
-            },
-            "overrides": [
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "igpu_rc6"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "percent"
-                  }
-                ]
+                "color": "green",
+                "value": null
               },
               {
-                "matcher": {
-                  "id": "byName",
-                  "options": "igpu_interrupts"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "recps"
-                  }
-                ]
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 12,
-            "y": 25
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "igpu_rc6"
             },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
           },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-              },
-              "editorMode": "code",
-              "expr": "igpu_rc6{instance=~\"${Instance}\"}",
-              "instant": false,
-              "legendFormat": "{{__name__}}",
-              "range": true,
-              "refId": "A"
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "igpu_interrupts"
             },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-              },
-              "editorMode": "code",
-              "expr": "igpu_interrupts{instance=~\"${Instance}\"}",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "{{__name__}}",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "R6 & Interrupts ",
-          "type": "timeseries"
+            "properties": [
+              {
+                "id": "unit",
+                "value": "recps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+          },
+          "editorMode": "code",
+          "expr": "gpu_rc6",
+          "instant": false,
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "orange",
-                    "value": 70
-                  },
-                  {
-                    "color": "red",
-                    "value": 85
-                  }
-                ]
-              },
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
-            "y": 25
-          },
-          "id": 12,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "10.4.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-              },
-              "editorMode": "code",
-              "expr": "igpu_period{instance=~\"${Instance}\"}",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Period",
-          "type": "stat"
+          "editorMode": "code",
+          "expr": "gpu_interrupts",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Misc",
-      "type": "row"
+      "title": "R6 & Interrupts ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "edvvtg0kxx9mod"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 8,
+        "y": 33
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.0-pre",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
+          },
+          "editorMode": "code",
+          "expr": "gpu_period",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Period",
+      "type": "stat"
     }
   ],
+  "preload": false,
   "refresh": "5s",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [
     "igpu",
     "intel",
     "transcoding"
   ],
   "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "cloud.host.jhofer.local:8081",
-          "value": "cloud.host.jhofer.local:8081"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "f9422c25-b9ee-4376-8bd2-6a67029728ce"
-        },
-        "definition": "label_values({job=\"intel-gpu_exporter\"},instance)",
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "Instance",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values({job=\"intel-gpu_exporter\"},instance)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
+    "list": []
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Intel iGPU",
+  "title": "Intel GPU",
   "uid": "ddittat0n2i9se",
-  "version": 9,
+  "version": 5,
   "weekStart": ""
 }

--- a/intel-gpu-exporter.py
+++ b/intel-gpu-exporter.py
@@ -1,166 +1,134 @@
 from prometheus_client import start_http_server, Gauge
 import os
-import sys
 import subprocess
 import json
 import logging
 
-igpu_engines_blitter_0_busy = Gauge(
-    "igpu_engines_blitter_0_busy", "Blitter 0 busy utilisation %"
-)
-igpu_engines_blitter_0_sema = Gauge(
-    "igpu_engines_blitter_0_sema", "Blitter 0 sema utilisation %"
-)
-igpu_engines_blitter_0_wait = Gauge(
-    "igpu_engines_blitter_0_wait", "Blitter 0 wait utilisation %"
-)
+gpu_period = Gauge("gpu_period", "Period ms")
 
-igpu_engines_render_3d_0_busy = Gauge(
-    "igpu_engines_render_3d_0_busy", "Render 3D 0 busy utilisation %"
-)
-igpu_engines_render_3d_0_sema = Gauge(
-    "igpu_engines_render_3d_0_sema", "Render 3D 0 sema utilisation %"
-)
-igpu_engines_render_3d_0_wait = Gauge(
-    "igpu_engines_render_3d_0_wait", "Render 3D 0 wait utilisation %"
-)
+gpu_frequency_actual = Gauge("gpu_frequency_actual", "Frequency actual MHz")
+gpu_frequency_requested = Gauge("gpu_frequency_requested", "Frequency requested MHz")
 
-igpu_engines_video_0_busy = Gauge(
-    "igpu_engines_video_0_busy", "Video 0 busy utilisation %"
-)
-igpu_engines_video_0_sema = Gauge(
-    "igpu_engines_video_0_sema", "Video 0 sema utilisation %"
-)
-igpu_engines_video_0_wait = Gauge(
-    "igpu_engines_video_0_wait", "Video 0 wait utilisation %"
-)
+gpu_interrupts = Gauge("gpu_interrupts", "Interrupts/s")
 
-igpu_engines_video_enhance_0_busy = Gauge(
-    "igpu_engines_video_enhance_0_busy", "Video Enhance 0 busy utilisation %"
-)
-igpu_engines_video_enhance_0_sema = Gauge(
-    "igpu_engines_video_enhance_0_sema", "Video Enhance 0 sema utilisation %"
-)
-igpu_engines_video_enhance_0_wait = Gauge(
-    "igpu_engines_video_enhance_0_wait", "Video Enhance 0 wait utilisation %"
-)
+gpu_rc6 = Gauge("gpu_rc6", "RC6 %")
 
-igpu_frequency_actual = Gauge("igpu_frequency_actual", "Frequency actual MHz")
-igpu_frequency_requested = Gauge("igpu_frequency_requested", "Frequency requested MHz")
+gpu_imc_bandwidth_reads = Gauge("gpu_imc_bandwidth_reads", "IMC reads MiB/s")
+gpu_imc_bandwidth_writes = Gauge("gpu_imc_bandwidth_writes", "IMC writes MiB/s")
 
-igpu_imc_bandwidth_reads = Gauge("igpu_imc_bandwidth_reads", "IMC reads MiB/s")
-igpu_imc_bandwidth_writes = Gauge("igpu_imc_bandwidth_writes", "IMC writes MiB/s")
+gpu_engines_render_3d_busy = Gauge("gpu_engines_render_3d_busy", "Render 3D 0 busy utilisation %")
+gpu_engines_render_3d_sema = Gauge("gpu_engines_render_3d_sema", "Render 3D 0 sema utilisation %")
+gpu_engines_render_3d_wait = Gauge("gpu_engines_render_3d_wait", "Render 3D 0 wait utilisation %")
 
-igpu_interrupts = Gauge("igpu_interrupts", "Interrupts/s")
+gpu_engines_blitter_busy = Gauge("gpu_engines_blitter_busy", "Blitter 0 busy utilisation %")
+gpu_engines_blitter_sema = Gauge("gpu_engines_blitter_sema", "Blitter 0 sema utilisation %")
+gpu_engines_blitter_wait = Gauge("gpu_engines_blitter_wait", "Blitter 0 wait utilisation %")
 
-igpu_period = Gauge("igpu_period", "Period ms")
+gpu_engines_video_enhance_busy = Gauge("gpu_engines_video_enhance_busy", "Video Enhance 0 busy utilisation %")
+gpu_engines_video_enhance_sema = Gauge("gpu_engines_video_enhance_sema", "Video Enhance 0 sema utilisation %")
+gpu_engines_video_enhance_wait = Gauge("gpu_engines_video_enhance_wait", "Video Enhance 0 wait utilisation %")
 
-igpu_power_gpu = Gauge("igpu_power_gpu", "GPU power W")
-igpu_power_package = Gauge("igpu_power_package", "Package power W")
+gpu_engines_video_busy = Gauge("gpu_engines_video_busy", "Video 0 busy utilisation %")
+gpu_engines_video_sema = Gauge("gpu_engines_video_sema", "Video 0 sema utilisation %")
+gpu_engines_video_wait = Gauge("gpu_engines_video_wait", "Video 0 wait utilisation %")
 
-igpu_rc6 = Gauge("igpu_rc6", "RC6 %")
+gpu_engines_compute_busy = Gauge("gpu_engines_compute_busy", "Compute busy utilisation %")
+gpu_engines_compute_sema = Gauge("gpu_engines_compute_sema", "Compute sema utilisation %")
+gpu_engines_compute_wait = Gauge("gpu_engines_compute_wait", "Compute wait utilisation %")
 
+gpu_power_gpu = Gauge("gpu_power_gpu", "GPU power W")
+gpu_power_package = Gauge("gpu_power_package", "Package power W")
 
 def update(data):
-    igpu_engines_blitter_0_busy.set(
-        data.get("engines", {}).get("Blitter/0", {}).get("busy", 0.0)
-    )
-    igpu_engines_blitter_0_sema.set(
-        data.get("engines", {}).get("Blitter/0", {}).get("sema", 0.0)
-    )
-    igpu_engines_blitter_0_wait.set(
-        data.get("engines", {}).get("Blitter/0", {}).get("wait", 0.0)
-    )
+    def get_engine(name):
+        engines = data.get("engines", {})
+        return engines.get(name, engines.get(name + "/0", {}))
 
-    igpu_engines_render_3d_0_busy.set(
-        data.get("engines", {}).get("Render/3D/0", {}).get("busy", 0.0)
-    )
-    igpu_engines_render_3d_0_sema.set(
-        data.get("engines", {}).get("Render/3D/0", {}).get("sema", 0.0)
-    )
-    igpu_engines_render_3d_0_wait.set(
-        data.get("engines", {}).get("Render/3D/0", {}).get("wait", 0.0)
-    )
+    period_data = data.get("period", {})
+    gpu_period.set(period_data.get("duration", 0))
 
-    igpu_engines_video_0_busy.set(
-        data.get("engines", {}).get("Video/0", {}).get("busy", 0.0)
-    )
-    igpu_engines_video_0_sema.set(
-        data.get("engines", {}).get("Video/0", {}).get("sema", 0.0)
-    )
-    igpu_engines_video_0_wait.set(
-        data.get("engines", {}).get("Video/0", {}).get("wait", 0.0)
-    )
+    freq = data.get("frequency", {})
+    gpu_frequency_actual.set(freq.get("actual", 0))
+    gpu_frequency_requested.set(freq.get("requested", 0))
 
-    igpu_engines_video_enhance_0_busy.set(
-        data.get("engines", {}).get("VideoEnhance/0", {}).get("busy", 0.0)
-    )
-    igpu_engines_video_enhance_0_sema.set(
-        data.get("engines", {}).get("VideoEnhance/0", {}).get("sema", 0.0)
-    )
-    igpu_engines_video_enhance_0_wait.set(
-        data.get("engines", {}).get("VideoEnhance/0", {}).get("wait", 0.0)
-    )
+    interrupts = data.get("interrupts", {})
+    gpu_interrupts.set(interrupts.get("count", 0))
 
-    igpu_frequency_actual.set(data.get("frequency", {}).get("actual", 0))
-    igpu_frequency_requested.set(data.get("frequency", {}).get("requested", 0))
+    rc6 = data.get("rc6", {})
+    gpu_rc6.set(rc6.get("value", 0))
 
-    igpu_imc_bandwidth_reads.set(data.get("imc-bandwidth", {}).get("reads", 0))
-    igpu_imc_bandwidth_writes.set(data.get("imc-bandwidth", {}).get("writes", 0))
+    imc = data.get("imc-bandwidth", {})
+    gpu_imc_bandwidth_reads.set(imc.get("reads", 0))
+    gpu_imc_bandwidth_writes.set(imc.get("writes", 0))
 
-    igpu_interrupts.set(data.get("interrupts", {}).get("count", 0))
+    render3d = get_engine("Render/3D")
+    gpu_engines_render_3d_busy.set(render3d.get("busy", 0.0))
+    gpu_engines_render_3d_sema.set(render3d.get("sema", 0.0))
+    gpu_engines_render_3d_wait.set(render3d.get("wait", 0.0))
 
-    igpu_period.set(data.get("period", {}).get("duration", 0))
+    blitter = get_engine("Blitter")
+    gpu_engines_blitter_busy.set(blitter.get("busy", 0.0))
+    gpu_engines_blitter_sema.set(blitter.get("sema", 0.0))
+    gpu_engines_blitter_wait.set(blitter.get("wait", 0.0))
 
-    igpu_power_gpu.set(data.get("power", {}).get("GPU", 0))
-    igpu_power_package.set(data.get("power", {}).get("Package", 0))
+    video = get_engine("Video")
+    gpu_engines_video_busy.set(video.get("busy", 0.0))
+    gpu_engines_video_sema.set(video.get("sema", 0.0))
+    gpu_engines_video_wait.set(video.get("wait", 0.0))
 
-    igpu_rc6.set(data.get("rc6", {}).get("value", 0))
+    video_enhance = get_engine("VideoEnhance")
+    gpu_engines_video_enhance_busy.set(video_enhance.get("busy", 0.0))
+    gpu_engines_video_enhance_sema.set(video_enhance.get("sema", 0.0))
+    gpu_engines_video_enhance_wait.set(video_enhance.get("wait", 0.0))
 
+    compute = get_engine("Compute")
+    gpu_engines_compute_busy.set(compute.get("busy", 0.0))
+    gpu_engines_compute_sema.set(compute.get("sema", 0.0))
+    gpu_engines_compute_wait.set(compute.get("wait", 0.0))
+
+    gpu_power_gpu.set(data.get("power", {}).get("GPU", 0))
+    gpu_power_package.set(data.get("power", {}).get("Package", 0))
 
 if __name__ == "__main__":
-    if os.getenv("DEBUG", False):
-        debug = logging.DEBUG
-    else:
-        debug = logging.INFO
-    logging.basicConfig(format="%(asctime)s - %(message)s", level=debug)
-
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s") 
+    
     start_http_server(8080)
-
-    period = os.getenv("REFRESH_PERIOD_MS", 10000)
-
-    cmd = "intel_gpu_top -J -s {}".format(int(period))
+    
+    period = int(os.getenv("REFRESH_PERIOD_MS", 10000))
+    cmd = f"intel_gpu_top -J -s {period}"
+    
     process = subprocess.Popen(
-        cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
     )
+    
+    logging.info(f"Started: {cmd}")
 
-    logging.info("Started " + cmd)
-    output = ""
+    buffer = ""
+    decoder = json.JSONDecoder()
 
-    if os.getenv("IS_DOCKER", False):
-        for line in process.stdout:
-            line = line.decode("utf-8").strip()
-            output += line
-
+    while process.poll() is None:
+        line = process.stdout.readline()
+        if not line:
+            continue
+        buffer += line
+        
+        if buffer.startswith("["):
+            buffer = buffer[1:]
+        
+        buffer = buffer.lstrip()
+        
+        while buffer:
             try:
-                data = json.loads(output.strip(","))
-                logging.debug(data)
-                update(data)
-                output = ""
+                obj, idx = decoder.raw_decode(buffer)
+                update(obj)
+                buffer = buffer[idx:].lstrip(",")
             except json.JSONDecodeError:
-                continue
-    else:
-        while process.poll() is None:
-            read = process.stdout.readline()
-            output += read.decode("utf-8")
-            logging.debug(output)
-            if read == b"},\n":
-                update(json.loads(output[:-2]))
-                output = ""
+                break
 
     process.kill()
-
     if process.returncode != 0:
-        logging.error("Error: " + process.stderr.read().decode("utf-8"))
-
-    logging.info("Finished")
+        error = process.stderr.read()
+        logging.error(f"Error: {error}")


### PR DESCRIPTION
feat: add compute engine metrics support
fix: use debian:trixie-slim instead of python:3.13-slim
fix: adapt json parsing for intel_gpu_top v2.28 output format
fix: grafana dashboard for compute engine

The installed intel_gpu_top version did not support my Arc A750, or not completely. The compute engine was recognized as [Unknown]. This was fixed with v2.28+. Debian bookworm (base image of python:3.13-slim) only has v2.27. 

JSON parsing was also no longer possible in the old way. 

I cannot check the GPU power point with my GPU because this value is not displayed in intel_gpu_top. So if someone has the possibility to check this, please add the panel to the grafana dashboar

TODO

- [ ] verify that GPU power can be read out on other GPUs