### PR TITLE
feat: select a specific GPU

### DIFF
--- a/intel-gpu-exporter.py
+++ b/intel-gpu-exporter.py
@@ -128,8 +128,13 @@ if __name__ == "__main__":
     start_http_server(8080)
 
     period = os.getenv("REFRESH_PERIOD_MS", 10000)
+    device = os.getenv("DEVICE")
 
-    cmd = "intel_gpu_top -J -s {}".format(int(period))
+    if device is not None:
+        cmd = "intel_gpu_top -J -s {} -d {}".format(int(period), device)
+    else:
+        cmd = "intel_gpu_top -J -s {}".format(int(period))
+
     process = subprocess.Popen(
         cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )


### PR DESCRIPTION
Currently if you have multiple GPUs, there is no way to select which one you want to monitor. This allows you to optionally set the DEVICE environment variable, which is passed in as the -d flag for intel_gpu_top 